### PR TITLE
Fix return type annotation

### DIFF
--- a/promptwizard/glue/common/llm/llm_mgr.py
+++ b/promptwizard/glue/common/llm/llm_mgr.py
@@ -5,7 +5,7 @@ from llama_index.core.llms import LLM
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 from ..base_classes import LLMConfig
 from ..constants.str_literals import InstallLibs, OAILiterals, \
-    OAILiterals, LLMLiterals, LLMOutputTypes
+    LLMLiterals, LLMOutputTypes
 from .llm_helper import get_token_counter
 from ..exceptions import GlueLLMException
 from ..utils.runtime_tasks import install_lib_if_missing

--- a/promptwizard/glue/promptopt/instantiate.py
+++ b/promptwizard/glue/promptopt/instantiate.py
@@ -3,9 +3,8 @@ import pickle
 import time
 from typing import Any
 
-from ..common.base_classes import LLMConfig, SetupConfig
+from ..common.base_classes import SetupConfig
 from ..common.constants.log_strings import CommonLogsStr
-from ..common.llm.llm_mgr import LLMMgr
 from ..common.utils.logging import get_glue_logger, set_logging_config
 from ..common.utils.file import read_jsonl, yaml_to_class, yaml_to_dict, read_jsonl_row
 from ..paramlogger import ParamLogger

--- a/promptwizard/glue/promptopt/instantiate.py
+++ b/promptwizard/glue/promptopt/instantiate.py
@@ -1,7 +1,7 @@
 from os.path import dirname, join
 import pickle
 import time
-from typing import Any
+from typing import Any, Tuple
 
 from ..common.base_classes import SetupConfig
 from ..common.constants.log_strings import CommonLogsStr
@@ -11,7 +11,6 @@ from ..paramlogger import ParamLogger
 from ..promptopt.constants import PromptOptimizationLiterals
 from ..promptopt.techniques.common_logic import DatasetSpecificProcessing
 from ..promptopt.utils import get_promptopt_class
-
 
 class GluePromptOpt:
     """
@@ -105,7 +104,7 @@ class GluePromptOpt:
         self.prompt_opt = prompt_opt_cls(training_dataset, base_path, self.setup_config,
                                          self.prompt_pool, self.data_processor, self.logger)
 
-    def get_best_prompt(self,use_examples=False,run_without_train_examples=False,generate_synthetic_examples=False) -> (str, Any):
+    def get_best_prompt(self,use_examples=False,run_without_train_examples=False,generate_synthetic_examples=False) -> Tuple[str, Any]:
         """
         Call get_best_prompt() method of class PromptOptimizer & return its value.
         :return: (best_prompt, expert_profile)
@@ -153,7 +152,7 @@ class GluePromptOpt:
         return total_correct / total_count
 
     @iolog.log_io_params
-    def predict_and_access(self, question: str, gt_answer: str) -> (bool, str, str):
+    def predict_and_access(self, question: str, gt_answer: str) -> Tuple[bool, str, str]:
         """
         For the given input question, get answer to it from LLM, using the BEST_PROMPT & EXPERT_PROFILE
         computes earlier.

--- a/promptwizard/glue/promptopt/utils.py
+++ b/promptwizard/glue/promptopt/utils.py
@@ -5,8 +5,10 @@ from .techniques.critique_n_refine.core_logic import CritiqueNRefine
 from .techniques.critique_n_refine.base_classes import CritiqueNRefineParams, \
     CritiqueNRefinePromptPool
 
+from typing import Tuple
 
-def get_promptopt_class(prompt_technique_name: str) -> (PromptOptimizer, PromptOptimizationParams, PromptPool):
+
+def get_promptopt_class(prompt_technique_name: str) -> Tuple[PromptOptimizer, PromptOptimizationParams, PromptPool]:
     """
     :params prompt_technique_name: Name of prompt optimization technique
     :return: Instance of class PromptRefinements, which is super class for all Prompt Optimization classes,


### PR DESCRIPTION
This pull request corrects the return type annotation for the instantiate/get_best_prompt, instantiate/predict_and_access and utils/get_promptopt_class methods. Additionally, unused imports were removed from the files.