### PR TITLE
bugfix: prefer shorter prompt; update few shot examples

### DIFF
--- a/promptwizard/glue/promptopt/techniques/critique_n_refine/core_logic.py
+++ b/promptwizard/glue/promptopt/techniques/critique_n_refine/core_logic.py
@@ -282,7 +282,7 @@ class CritiqueNRefine(PromptOptimizer, UniversalBaseClass):
         :return: List of top `top_n` prompts.
         """
         sorted_prompts = sorted(prompt_score_list, key=lambda x: [x[self.GetPromptScoreIndex.SCORE],
-                                                                  len(x[self.GetPromptScoreIndex.PROMPT_STR])],
+                                                                  -len(x[self.GetPromptScoreIndex.PROMPT_STR])],
                                 reverse=True)
         sorted_top_n_prompts = sorted_prompts[:top_n]
         self.logger.debug(f"Sorted top n prompts:  {sorted_top_n_prompts}")
@@ -530,7 +530,7 @@ class CritiqueNRefine(PromptOptimizer, UniversalBaseClass):
                     break
 
             if len(examples) < params.few_shot_count:
-                examples = random.sample(self.dataset, params.few_shot_count - len(examples))
+                examples += random.sample(self.dataset, params.few_shot_count - len(examples))
 
             # Refine task description and examples iteratively
             print("\nRefining Task description and Examples iteratively....")


### PR DESCRIPTION
1. In the function `select_top_prompts`, the `sorted` function is utilized to rank the generated prompts based on their scores and lengths. However, the `key` parameter may cause the optimizer to favor longer prompts, which is not reasonable. Shorter prompts generally provide better robustness in practice.
The updated code is  as follows:
`sorted_prompts = sorted(prompt_score_list, key=lambda x: [x[self.GetPromptScoreIndex.SCORE],
                                                                  -len(x[self.GetPromptScoreIndex.PROMPT_STR])], reverse=True)`

2. In the function `get_best_prompt`, when the number of few-shot examples is insufficient, the logic randomly selects `params.few_shot_count - len(examples)` examples from the dataset currently, which is not a reasonable approach.
The updated code is as follows:
`examples += random.sample(self.dataset, params.few_shot_count - len(examples))`